### PR TITLE
Unify terrain vs texture naming

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -23,7 +23,7 @@ export const Select = memo(
   }) => (
     <div className="flex items-center">
       <label className="font-bold mr-2" htmlFor={id}>
-        {label}
+        {label}:
       </label>
       <select
         className={[

--- a/src/util/algorithms/dijkstra/index.ts
+++ b/src/util/algorithms/dijkstra/index.ts
@@ -27,7 +27,7 @@ export function* getDijkstraGenerator(
     if (currentCoordinateData.distanceFromStart === Infinity) {
       return {
         type: "COMPLETE_CALCULATION",
-        pathFound: false,
+        isPathFound: false,
       };
     }
 
@@ -69,7 +69,7 @@ export function* getDijkstraGenerator(
 
   return {
     type: "COMPLETE_CALCULATION",
-    pathFound: true,
+    isPathFound: true,
   };
 }
 

--- a/src/util/algorithms/dijkstra/types.ts
+++ b/src/util/algorithms/dijkstra/types.ts
@@ -13,7 +13,7 @@ interface AddPathCoordinate {
 
 export interface CompleteCalculation {
   type: "COMPLETE_CALCULATION";
-  pathFound: boolean;
+  isPathFound: boolean;
 }
 
 export interface CoordinateData {

--- a/src/views/PathFindingMap/Node/index.tsx
+++ b/src/views/PathFindingMap/Node/index.tsx
@@ -21,7 +21,7 @@ export const Node = ({
     () => [rowIndex, columnIndex],
     [rowIndex, columnIndex],
   );
-  const { start, end, path, textureMap: terrain } = usePathFindingContext();
+  const { start, end, path, textureMap } = usePathFindingContext();
   const dispatchPath = usePathFindingDispatchContext();
 
   const userAction = useUserActionContext();
@@ -38,8 +38,8 @@ export const Node = ({
   );
 
   const currentTexture = useMemo(
-    () => terrain.getCoordinate(coordinate),
-    [terrain, coordinate],
+    () => textureMap.getCoordinate(coordinate),
+    [textureMap, coordinate],
   );
 
   const currentPathState = useMemo(

--- a/src/views/PathFindingMap/index.tsx
+++ b/src/views/PathFindingMap/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../contexts/UserActionContext";
 
 export const PathFindingMap = () => {
-  const { textureMap: terrain } = usePathFindingContext();
+  const { textureMap } = usePathFindingContext();
   const userAction = useUserActionContext();
   const dispatchUserAction = useUserActionDispatchContext();
 
@@ -27,7 +27,7 @@ export const PathFindingMap = () => {
 
   return (
     <div className="grid grid-cols-35 gap-0.5 my-4" onMouseLeave={onMouseLeave}>
-      {terrain.values.map((row, i) =>
+      {textureMap.values.map((row, i) =>
         row.map((_, j) => (
           <Node rowIndex={i} columnIndex={j} key={`${i}-${j}`} />
         )),

--- a/src/views/Toolbar/ActionButton/FindPathButton.tsx
+++ b/src/views/Toolbar/ActionButton/FindPathButton.tsx
@@ -17,17 +17,17 @@ export const FindPathButton = ({
 }) => {
   const { openModal } = useModalContext();
   const dispatchUserAction = useUserActionDispatchContext();
-  const { start, end, textureMap: terrainMap } = usePathFindingContext();
+  const { start, end, textureMap } = usePathFindingContext();
   const dispatchPath = usePathFindingDispatchContext();
 
   const afterDijkstraSuccess = useCallback(
-    (failedMessage?: string) => {
+    (isPathFound: boolean) => {
       setCurrentInterval(null);
       dispatchPath({
         type: "CLEAR_VISITED_COORDINATES",
       });
 
-      if (failedMessage) {
+      if (isPathFound) {
         openModal();
         setFindPathButton("findPath");
         return;
@@ -43,14 +43,12 @@ export const FindPathButton = ({
     dispatchUserAction({
       type: "NO_ACTION",
     });
-    const dijkstraGenerator = getDijkstraGenerator(start, end, terrainMap);
+    const dijkstraGenerator = getDijkstraGenerator(start, end, textureMap);
     const interval = setInterval(() => {
       const generated = dijkstraGenerator.next();
       if (generated.done) {
         clearInterval(interval);
-        afterDijkstraSuccess(
-          generated.value.pathFound ? undefined : "Path not found",
-        );
+        afterDijkstraSuccess(generated.value.isPathFound);
       } else {
         switch (generated.value.type) {
           case "ADD_VISITED_COORDINATE":
@@ -71,7 +69,7 @@ export const FindPathButton = ({
   }, [
     start,
     end,
-    terrainMap,
+    textureMap,
     afterDijkstraSuccess,
     dispatchPath,
     dispatchUserAction,

--- a/src/views/Toolbar/ActionButton/FindPathButton.tsx
+++ b/src/views/Toolbar/ActionButton/FindPathButton.tsx
@@ -27,7 +27,7 @@ export const FindPathButton = ({
         type: "CLEAR_VISITED_COORDINATES",
       });
 
-      if (isPathFound) {
+      if (!isPathFound) {
         openModal();
         setFindPathButton("findPath");
         return;

--- a/src/views/Toolbar/SelectTerrain.tsx
+++ b/src/views/Toolbar/SelectTerrain.tsx
@@ -49,7 +49,7 @@ export const SelectTerrain = ({ disabled }: { disabled: boolean }) => {
   return (
     <Select
       id="select-sample"
-      label="Sample Terrains:"
+      label="Sample Terrains"
       value={sampleTerrain == null ? "none" : sampleTerrain}
       onChange={handleSampleTerrainChange}
       disabled={disabled}

--- a/src/views/Toolbar/SelectTexture.tsx
+++ b/src/views/Toolbar/SelectTexture.tsx
@@ -63,7 +63,7 @@ export const SelectTexture = ({ disabled }: { disabled: boolean }) => {
   return (
     <Select
       id="select-texture"
-      label="Draw Texture:"
+      label="Draw Texture"
       value={currentTexture == null ? "none" : currentTexture.toString()}
       disabled={disabled}
       onChange={onChange}


### PR DESCRIPTION
- Texture is an individual weight value for a given coordinate
- A terrain is a presaved map of textures
- Also unified the `Select` label to use semicolons by default 